### PR TITLE
Update to latest version of args library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "xrstf/composer-php52": "~1.0",
-    "lucatume/args": "~0.1.9"
+    "lucatume/args": "~1.0.1"
   },
   "require-dev": {
     "lucatume/wp-browser": "~1.15"


### PR DESCRIPTION
Without the latest version of args, I get a fatal error:

```
( ! ) Fatal error: Uncaught Error: Call to undefined method StringArg::in() in plugins/cmb2-pipes/src/TAD/Pipe/PipeFactory.php on line 26
```
